### PR TITLE
fix: change ipfs-cid and egg-http-logger for npm regestry

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "egg": "^2.15.1",
     "egg-easynft": "file:./plugins/easynft",
-    "egg-http-logger": "git+https://github.com/kiba-zhao/egg-http-logger.git",
+    "egg-http-logger": "^0.1.0",
     "egg-scripts": "^2.11.0",
     "ipfs-http-client": "^50.1.1"
   },

--- a/server/plugins/easynft/package.json
+++ b/server/plugins/easynft/package.json
@@ -17,7 +17,7 @@
     "bignumber.js": "^9.0.1",
     "cids": "^1.1.6",
     "http-errors": "^1.8.0",
-    "ipfs-cid": "git+https://github.com/MatrixStorageTech2021/ipfs-cid.git",
+    "ipfs-cid": "^0.1.0",
     "json-bigint": "^1.0.0",
     "urlencode": "^1.1.0"
   },


### PR DESCRIPTION
fix: change ipfs-cid and egg-http-logger for npm regestry